### PR TITLE
Utilizing workerThreads for communication back and forth with the client

### DIFF
--- a/src/cs455/scaling/AutomaticExit.java
+++ b/src/cs455/scaling/AutomaticExit.java
@@ -1,0 +1,24 @@
+package cs455.scaling;
+import java.util.concurrent.SynchronousQueue;
+
+
+public class AutomaticExit extends Thread{
+
+    int numMinutes = 5;
+
+    public AutomaticExit(){};
+
+    public AutomaticExit(int numMinutes){
+        this.numMinutes = numMinutes;
+    }
+
+    @Override
+    public void run(){
+        try{
+            Thread.sleep(1000 * 60 * numMinutes);
+        }
+        catch(InterruptedException e) {
+        }
+        System.exit(0);
+    }
+}

--- a/src/cs455/scaling/BatchTimer.java
+++ b/src/cs455/scaling/BatchTimer.java
@@ -1,0 +1,36 @@
+package cs455.scaling;
+
+public class BatchTimer extends Thread{
+
+    private int batchTime = 1;
+    private boolean batchTimerStarted = false;
+    private boolean batchReady = false;
+
+    public BatchTimer(int batchTime){
+        this.batchTime = batchTime;
+    }
+
+    public synchronized boolean getBatchReadyStatus(){
+        return batchReady;
+    }
+
+    private synchronized void setBatchReady(boolean batchStatus){
+        batchReady = batchStatus;
+    }
+
+    @Override
+    public void run(){
+        while (true){
+            if (getBatchReadyStatus() == false){
+                try{
+                    Thread.sleep(1000*batchTime);
+                }
+                catch(InterruptedException e){
+                    e.printStackTrace();
+                }
+                setBatchReady(true);
+            }
+        }
+    }
+
+}

--- a/src/cs455/scaling/HashMessage.java
+++ b/src/cs455/scaling/HashMessage.java
@@ -36,6 +36,15 @@ public class HashMessage {
 		return hashedString;
 	}
 
+	public String bytesToString(byte[] inputBytes){
+		String byteString = "";
+		for (byte b: inputBytes){
+			byteString += b;
+		}
+		return byteString;
+
+	}
+
 	public String SHA1FromBytes(byte[] data) {
 		try{
 			MessageDigest digest = MessageDigest.getInstance("SHA1"); 

--- a/src/cs455/scaling/KeySelector.java
+++ b/src/cs455/scaling/KeySelector.java
@@ -1,0 +1,95 @@
+// The purpose of this class is to register  and  deregister incoming SelectionKeys on the server side.
+package cs455.scaling;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.SynchronousQueue;
+
+
+
+public class KeySelector extends Thread{
+
+    private ThreadPoolManager tpm;
+    private int portnum = -1;
+	public static Selector selector;
+	public static ServerSocketChannel serverSocket;
+
+    public KeySelector(ThreadPoolManager tpm, Selector selector, int portnum){
+        this.tpm = tpm;
+		this.selector = selector;
+		this.portnum = portnum;
+    }
+
+	// This was used for registering from the workerThread, but registering from the workerThread doesn't currently work
+	// public ServerSocketChannel getServerSocketChannel(){
+	// 	return this.serverSocket;
+	// }
+
+	@Override
+	public void run() {
+		try {
+			// Selector selector = Selector.open(); // The selector is opened from ThreadPoolManager instead.
+			serverSocket = ServerSocketChannel.open();
+			serverSocket.bind(new InetSocketAddress(portnum));
+			serverSocket.configureBlocking(false);
+
+			serverSocket.register(selector, SelectionKey.OP_ACCEPT);
+
+			int numKeysRead = 0;
+
+			while (true) {
+				// System.out.println("Listening for new connections or messages");
+				selector.select();
+				// System.out.println("\tActivity on selector!");
+				Set<SelectionKey> selectedKeys = selector.selectedKeys();
+				Iterator<SelectionKey> iter = selectedKeys.iterator();
+
+				while (iter.hasNext()) {
+					// System.out.println("Number of keys is " + selectedKeys.size());
+					// System.out.println("Number of keys read so far is " + ++numKeysRead);
+					SelectionKey key = iter.next();
+					
+					if (key.isValid() == false) {
+						continue;
+					}
+
+					// Open new connection on serverSocket
+					if (key.isAcceptable()) {
+						// Registering is currently handled by the selector itself, not sure if the workerThreads are supposed to handle registering, but workerNodes handling registering does not currently work
+						register();
+					}
+
+					// Read data from previous connection
+					if (key.isReadable()) {
+						//Add read-write task to pendingTasks in threadPoolManager so that the threadPools can handle those
+						tpm.addTask(key);
+					}
+
+					// Remove from the set when done
+					iter.remove();
+				}
+			}
+		}
+		catch (IOException e){
+			e.printStackTrace();
+		}
+	}
+
+	public synchronized static void register() throws IOException {
+		SocketChannel client = serverSocket.accept();
+		client.configureBlocking(false);
+		client.register(selector, SelectionKey.OP_READ);
+		System.out.println("\t\tNew client registered using selector");
+	}
+
+}

--- a/src/cs455/scaling/KeySelector.java
+++ b/src/cs455/scaling/KeySelector.java
@@ -1,4 +1,4 @@
-// The purpose of this class is to register  and  deregister incoming SelectionKeys on the server side.
+// The purpose of this class is to house the selector object itself and to keep reading for new keys to either register into the selector system or add to the queue for other workerThreads to handle
 package cs455.scaling;
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/src/cs455/scaling/KeySelector.java
+++ b/src/cs455/scaling/KeySelector.java
@@ -92,6 +92,7 @@ public class KeySelector extends Thread{
 		SocketChannel client = serverSocket.accept();
 		client.configureBlocking(false);
 		client.register(selector, SelectionKey.OP_READ);
+		this.tpm.incrementNodesConnected();
 		System.out.println("\t\tNew client registered using selector");
 		notify();
 	}

--- a/src/cs455/scaling/PrintStatsThread.java
+++ b/src/cs455/scaling/PrintStatsThread.java
@@ -1,8 +1,14 @@
 package cs455.scaling;
-
+import java.lang.Object.*;
+import java.text.DecimalFormat;
 import java.lang.Thread;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Date;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Vector;
 
 public class PrintStatsThread extends Thread{
 
@@ -10,6 +16,9 @@ public class PrintStatsThread extends Thread{
     ThreadPoolManager tpm;
     private enum type {TPM, CLIENT};
     private type nodeType;
+    private Instant startTime;
+    private Vector<Double> throughPutAverages = new Vector<Double>();
+
 
     public PrintStatsThread(Client client){
         this.client = client;
@@ -19,8 +28,30 @@ public class PrintStatsThread extends Thread{
     public PrintStatsThread(ThreadPoolManager tpm){
         this.tpm = tpm;
         this.nodeType = type.TPM;
+        this.startTime = Instant.now();
     }
 
+    private double getStandardDev(Object[] inputArray){
+        double arraySum = 0.0, stdDev = 0.0;
+
+        for(Object nextNum : inputArray) {
+            arraySum += (double) nextNum;
+        }
+       
+        double arrayLength = (double) inputArray.length;
+        // System.out.println("Array is this long: " + arrayLength);
+        double arrayMean = arraySum/arrayLength;
+        // System.out.println("Array has mean: " + arrayMean);
+
+        for(Object nextNum: inputArray) {
+            stdDev += Math.pow((double)nextNum - arrayMean, 2);
+        }
+        // System.out.println("stdDev is : " + stdDev);
+        // double insideParams = stdDev/arrayLength;
+        // System.out.println("stdDev is : " + insideParams);
+
+        return Math.sqrt(stdDev/arrayLength);
+    }
 
     @Override
     public void run() {
@@ -46,8 +77,22 @@ public class PrintStatsThread extends Thread{
                 while (true) {
                     //	long currentTime = date.getTime();
                     LocalDateTime currentTime = LocalDateTime.now();
-//                int totalSent = client.getTotalSent();
-                    System.out.println("[" + currentTime + "] Server Throughput: " + tpm.getTotalSent() + " messages/s, Active Client Connections: " + tpm.getNumNodesConnected() + ", Mean Per-client Throughput: " + tpm.getMeanClientThroughput() + " messages/s, Std. Dev. Of Per-client Throughput: " + tpm.getStdDevThroughput() + " messages/s");
+                    Instant endTime = Instant.now();
+                    long preciseDuration = (Duration.between(startTime, endTime).toMillis()) / 1000; // converting per millisecond unit rate to per second rate (1000ms = 1s) 
+                    preciseDuration = preciseDuration == 0 ? 1 : preciseDuration; // Prevent divide by zero error if the program just started and the timer hasn't started yet
+                    double averageSent = (double)(tpm.getTotalSent()) / (double) preciseDuration;
+                    // System.out.println("(long)(tpm.getTotalSent()) " + (long)(tpm.getTotalSent()));
+                    long numNodesConnected = (long) tpm.getNumNodesConnected() == 0 ? 1 : (long) tpm.getNumNodesConnected(); // Prevent divide by zero error if the program just started and no nodes have connected yet
+                    double meanPerClientTP = averageSent / (double) numNodesConnected;
+                    throughPutAverages.add(meanPerClientTP);
+                    Object[] tpaArray = throughPutAverages.toArray();
+                    // avgStats.accept(meanPerClientTP);
+                    double stdDev = getStandardDev(tpaArray);
+                    DecimalFormat df = new DecimalFormat ("#.000");
+                    df.format(stdDev);
+                    df.format(meanPerClientTP);
+                    // System.out.println("Duration is " + preciseDuration);
+                    System.out.println("[" + currentTime + "] Server Throughput: " + averageSent + " messages/s, Active Client Connections: " + tpm.getNumNodesConnected() + ", Mean Per-client Throughput: " + meanPerClientTP + " messages/s, Std. Dev. Of Per-client Throughput: " + stdDev + " messages/s");
                     Thread.sleep(20000);
                 }
             } catch (Exception e) {

--- a/src/cs455/scaling/Selector.java
+++ b/src/cs455/scaling/Selector.java
@@ -1,6 +1,0 @@
-// The purpose of this class is to register  and  deregister incoming SelectionKeys on the server side.  You should also be able to create randomized data packets as byte arrays
-
-
-public class Selector {
-
-}

--- a/src/cs455/scaling/Server.java
+++ b/src/cs455/scaling/Server.java
@@ -16,6 +16,8 @@ public class Server {
 	public static void main(String[] args) throws IOException {
 	
 		if (args.length == 4){
+			AutomaticExit ae = new AutomaticExit(1);
+			ae.start();
 			// First argument is portnum
 			int portnum = Integer.parseInt(args[0]);
 			// Second argument is thread-pool-size
@@ -27,6 +29,7 @@ public class Server {
 			System.out.println("Starting server w/ portnum: " + portnum + ", threadPoolSize: " + threadPoolSize + ", batchSize: " + batchSize + ", batchTime: " + batchTime + " seconds.");
 			ThreadPoolManager tpm = new ThreadPoolManager(portnum, threadPoolSize, batchSize, batchTime);
 			tpm.checkForNewKeys();
+
 
 
 		}

--- a/src/cs455/scaling/Server.java
+++ b/src/cs455/scaling/Server.java
@@ -26,7 +26,7 @@ public class Server {
 			int batchTime = Integer.parseInt(args[3]);
 			System.out.println("Starting server w/ portnum: " + portnum + ", threadPoolSize: " + threadPoolSize + ", batchSize: " + batchSize + ", batchTime: " + batchTime + " seconds.");
 			ThreadPoolManager tpm = new ThreadPoolManager(portnum, threadPoolSize, batchSize, batchTime);
-			tpm.run();
+			tpm.checkForNewKeys();
 
 
 		}

--- a/src/cs455/scaling/ThreadPoolManager.java
+++ b/src/cs455/scaling/ThreadPoolManager.java
@@ -69,8 +69,7 @@ public class ThreadPoolManager extends Thread{
 		 	allWorkerThreads.add(nextWorker);
 		}
 
-
-		
+		// This is the selector that scans for new keys, registers new nodes, and creates new jobs.
 		KeySelector ks = new KeySelector(this, selector, portnum);
 		ks.start();
 	}

--- a/src/cs455/scaling/ThreadPoolManager.java
+++ b/src/cs455/scaling/ThreadPoolManager.java
@@ -15,7 +15,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.SynchronousQueue;
 
 
-public class ThreadPoolManager{
+public class ThreadPoolManager extends Thread{
 
 	private int totalMessagesSent = 0;
 	private int totalMessagesReceived = 0;
@@ -23,15 +23,24 @@ public class ThreadPoolManager{
 
 	// Number of threads to initialize and keep alive for the duration of the program
 	private final int numThreads;
+
 	// Port Number the Server is listening on
 	private final int portnum;
+
+	// Maximum size of the list of pending tasks for workerThreads to handle
 	private final int batchSize;
+	
+	// Maximum time duration that tasks should be sitting in the pendingTasks queue before being assigned to workerThreads 
 	private final int batchTime;
 
-	// TODO: Data structure for containing all the threads here
+	// Copy of the selector used in KeySelector (//TODO: Determine if this is necessary as a class variable)
+	public static Selector selector;
+
+	// Data structure for containing all the threads
 	private HashSet<WorkerThread> allWorkerThreads = new HashSet<>();
-	// TODO: Data structure for queue of pending tasks here
-	protected LinkedBlockingDeque<SelectionKey> pendingTasks; // This is one of the 7 different types of implementations of the BlockingQueue interface, (this is likely? the one we want)
+
+	// Data structure for queue of pending tasks
+	protected static LinkedBlockingDeque<SelectionKey> pendingTasks; // This is one of the 7 different types of implementations of the BlockingQueue interface, (this is likely? the one we want)
 
 
 	public ThreadPoolManager(int portnum, int numThreads, int batchSize, int batchTime){
@@ -46,19 +55,38 @@ public class ThreadPoolManager{
 		PrintStatsThread pst = new PrintStatsThread(this);
 		pst.start();
 
-
-		// Create {numThreads} number of threads here and add them to the thread pool, initializing all them in the idle state.
-		 for (int i = 0; i < numThreads; i++){
-			 WorkerThread nextWorker = new WorkerThread();
-			 // nextWorker.start();
+		try{
+			this.selector = Selector.open();
+		}
+		catch (IOException e){
+			e.printStackTrace();
+		}
+		
+		// This creates and initializes all the workerThreads 
+		for (int i = 0; i < numThreads; i++){
+			WorkerThread nextWorker = new WorkerThread(i, this.selector);
+			nextWorker.start();
 		 	allWorkerThreads.add(nextWorker);
-		 }
+		}
+
+
+		
+		KeySelector ks = new KeySelector(this, selector, portnum);
+		ks.start();
 	}
 
+	public synchronized LinkedBlockingDeque<SelectionKey> getTaskList(){
+		return pendingTasks;
+	} 
 
-//	public void assignTask(/* params? here */){ //Purpose: Assign task to a thread
-//		return;
-//	}
+	public void addTask(SelectionKey key){
+		boolean keyGotInserted = false;
+		while (keyGotInserted == false){
+			if (pendingTasks.offerLast(key) == true){
+				keyGotInserted = true;
+			}
+		}
+	}
 
 	public int getTotalSent(){
 		return totalMessagesSent;
@@ -83,89 +111,43 @@ public class ThreadPoolManager{
 		return 0.0;
 	}
 
+	public void checkForNewKeys(){
 
-	//@Override
-	public void run() {
-		try {
-			Selector selector = Selector.open();
-			ServerSocketChannel serverSocket = ServerSocketChannel.open();
-			serverSocket.bind(new InetSocketAddress(portnum));
-			serverSocket.configureBlocking(false);
 
-			serverSocket.register(selector, SelectionKey.OP_ACCEPT);
-
-			while (true) {
-				System.out.println("Listening for new connections or messages");
-
-				selector.select();
-
-				System.out.println("\tActivity on selector!");
-
-				Set<SelectionKey> selectedKeys = selector.selectedKeys();
-
-				Iterator<SelectionKey> iter = selectedKeys.iterator();
-				while (iter.hasNext()) {
-
-					SelectionKey key = iter.next();
-					
-					if (key.isValid() == false) {
-						continue;
+		while (true){
+			// Use this for debugging the pendingTasks queue if keys in it are not being taken by the workerThreads for some reason.
+			// try{
+			// 	// Thread.sleep(3000);
+			// 	System.out.println("Size of pendingTasks is: " + pendingTasks.size() + ", waiting for size to reach: " + batchSize);
+			// }
+			// catch (InterruptedException e){
+			// 	e.printStackTrace();
+			// }
+			int i = 0;
+			if (this.pendingTasks.size() == batchSize){
+				while (this.pendingTasks.size() != 0){ // Start assigning keys to threads until it's empty
+					for(SelectionKey key : pendingTasks){
+						WorkerThread nextWorker = getNextAvailableWorker(); // Get the next available worker, this is a blocking call that waits until one is available
+						if (nextWorker != null){
+							// System.out.println("Worker #" + nextWorker.workerID + " is available");
+							nextWorker.setNextKey(key);
+							nextWorker.setWorkingStatus();
+							pendingTasks.remove(key);
+						}
 					}
-
-					// Open new connection on serverSocket
-					if (key.isAcceptable()) {
-						// key.attach(this) may be useful for passing an instance of this class to the workerThread so it may increment sent/received messages here
-						pendingTasks.add(key);
-						register(selector, serverSocket); //TODO: Make the workerThread register instead of the ThreadPoolManager
-					}
-
-					// Read data from previous connection
-					if (key.isReadable()) {
-						pendingTasks.add(key);
-						readAndRespond(key); //TODO: Make the workerThread register instead of the ThreadPoolManager
-					}
-
-					// Remove from the set when done
-					iter.remove();
 				}
 			}
 		}
-		catch (IOException e){
-			e.printStackTrace();
+	}
+
+	private WorkerThread getNextAvailableWorker(){
+		while (true){
+			for (WorkerThread wt : allWorkerThreads){
+				if (wt.isAvailable()){
+					return wt;
+				}
+			}	
 		}
 	}
 
-		private static void register(Selector selector, ServerSocketChannel serverSocket) throws IOException {
-			SocketChannel client = serverSocket.accept();
-
-			client.configureBlocking(false);
-			client.register(selector, SelectionKey.OP_READ);
-			System.out.println("\t\tNew client registered.");
-		}
-
-		private static void readAndRespond(SelectionKey key) throws IOException {
-			ByteBuffer readBuffer = ByteBuffer.allocate(8 * Constants.KB);
-			SocketChannel client = (SocketChannel) key.channel();
-
-			int bytesRead = client.read(readBuffer);
-
-			if (bytesRead == -1){
-				client.close();
-				System.out.println("Client has disconnected");
-			}
-			else {
-				byte[] receivedByteArray = readBuffer.array();
-				HashMessage receivedHashMessage = new HashMessage(receivedByteArray);
-				String hashedMessageString = receivedHashMessage.getHashedString();
-				System.out.println("Message being sent to client: " + hashedMessageString);
-				readBuffer.clear();
-				ByteBuffer writeBuffer = ByteBuffer.allocate(hashedMessageString.getBytes().length);
-				writeBuffer = ByteBuffer.wrap(hashedMessageString.getBytes());
-				client.write(writeBuffer);
-				writeBuffer.clear();
-			}
-		}
-
-
-
-	}
+}

--- a/src/cs455/scaling/ThreadPoolManager.java
+++ b/src/cs455/scaling/ThreadPoolManager.java
@@ -23,6 +23,9 @@ public class ThreadPoolManager extends Thread{
 	// Number of threads to initialize and keep alive for the duration of the program
 	private final int numThreads;
 
+	// Number of threads to initialize and keep alive for the duration of the program
+	private int totalNumConnections;
+
 	// Port Number the Server is listening on
 	private final int portnum;
 
@@ -91,19 +94,16 @@ public class ThreadPoolManager extends Thread{
 		return totalMessagesReceived;
 	}
 
-	public int getNumNodesConnected(){
-		//TODO Implement datastructure for holding nodes and grab the size of the datastructure here.
-		return 0;
+	public synchronized void decrementNodesConnected(){
+		--totalNumConnections;
+	}	
+
+	public synchronized void incrementNodesConnected(){
+		++totalNumConnections;
 	}
 
-	public double getMeanClientThroughput(){
-		//TODO Calculate mean client throughput and return here
-		return 0.0;
-	}
-
-	public double getStdDevThroughput(){
-		//TODO Calculate std dev of client throughput and return here
-		return 0.0;
+	public synchronized int getNumNodesConnected(){
+		return totalNumConnections;
 	}
 
 	public synchronized void incrementTotalReceived(){

--- a/src/cs455/scaling/WorkerThread.java
+++ b/src/cs455/scaling/WorkerThread.java
@@ -1,29 +1,104 @@
 package cs455.scaling;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.SynchronousQueue;
 
 public class WorkerThread extends Thread{
 
     private boolean isAvailable = false;
+    private ThreadPoolManager tpm;
+    private SelectionKey nextKey = null;
+    static Selector selector;
+    public int workerID = -1;
 
-    public WorkerThread(){};
+    public WorkerThread(int workerID, Selector selector){
+        this.workerID = workerID;
+        this.selector = selector;
+    };
 
     public boolean isAvailable(){
         return this.isAvailable;
     }
 
+    public void setWorkingStatus(){
+        isAvailable = false;
+    }
+
     private synchronized void waitForNewTask() {
-        try{
             this.isAvailable = true; // Worker is available and waiting
-            wait(); //TODO: Call notify() on this object to make it start executing
-            this.isAvailable = false; //Worker is no longer available and no longer waiting
+            boolean gotNextKey = false;
+            while (gotNextKey == false){
+                try{
+                    Thread.sleep(3000);
+                    // System.out.println("\t\t %%% Worker # " +workerID + " is waiting for a key to begin working, is it here yet? ->" + (nextKey == null));
+                }
+                catch (InterruptedException e){
+                    e.printStackTrace();
+                }
+                
+                if (this.nextKey != null){
+                    // System.out.println("\t\t $$$ WorkerThread # " + workerID + " received key, it is now working.");
+                    gotNextKey = true;
+                }
+            }
+    }
+
+    public void setNextKey(SelectionKey nextKey){
+        this.nextKey = nextKey;
+    }
+
+    private void completeNextTask(){
+
+        try{
+            // This block of code actually breaks the program, the selector in KeySelector.java apparently has to do registering or else the selector refuses to read beyond the first key it receives.
+	        // if (nextKey.isAcceptable()) {
+            //     KeySelector ks = (KeySelector) nextKey.attachment();
+            //     ServerSocketChannel ss = ks.getServerSocketChannel();
+            //     ks.register();
+            // }
+    
+            if (nextKey.isReadable()) {
+                this.readAndRespond(nextKey, workerID);
+            }
         }
-        catch (InterruptedException e){
+        catch (IOException e){
             e.printStackTrace();
         }
     }
 
-    private void completeNextTask(){
-        //TODO: Add functionality to make worker complete next task, do this by grabbing the next task from the blockingQueue in ThreadPoolManager
-    }
+	public static void readAndRespond(SelectionKey key, int workerID) throws IOException {
+			ByteBuffer readBuffer = ByteBuffer.allocate(8 * Constants.KB);
+			SocketChannel client = (SocketChannel) key.channel();
+			int bytesRead = client.read(readBuffer);
+
+			if (bytesRead == -1){
+				client.close();
+				System.out.println("Client has disconnected **FROM WORKERTHREAD #" + workerID);
+			}
+			else {
+				byte[] receivedByteArray = readBuffer.array();
+				HashMessage receivedHashMessage = new HashMessage(receivedByteArray);
+				String hashedMessageString = receivedHashMessage.getHashedString();
+				System.out.println("Message being sent **FROM WORKERTHREAD # " + workerID + " to client : " + hashedMessageString);
+				readBuffer.clear();
+				ByteBuffer writeBuffer = ByteBuffer.allocate(hashedMessageString.getBytes().length);
+				writeBuffer = ByteBuffer.wrap(hashedMessageString.getBytes());
+				client.write(writeBuffer);
+				writeBuffer.clear();
+			}
+		}
+
 
 
     @Override
@@ -34,8 +109,8 @@ public class WorkerThread extends Thread{
             waitForNewTask();
             // Do task
             completeNextTask();
-            // Repeat
+            // Set task as complete by marking this key as null; 
+            this.nextKey = null;
         }
-//        super.run();
     }
 }

--- a/src/cs455/scaling/WorkerThread.java
+++ b/src/cs455/scaling/WorkerThread.java
@@ -76,12 +76,13 @@ public class WorkerThread extends Thread{
         System.out.println("Worker # " + workerID + "\t Finished task.");
     }
 
-	public static void readAndRespond(SelectionKey key, int workerID) throws IOException {
+	public void readAndRespond(SelectionKey key, int workerID) throws IOException {
 			ByteBuffer readBuffer = ByteBuffer.allocate(Constants.KB * 8);
 			SocketChannel client = (SocketChannel) key.channel();
 			int bytesRead = client.read(readBuffer);
 
 			if (bytesRead == -1){
+                tpm.decrementNodesConnected();
 				client.close();
 				System.out.println("Client has disconnected **FROM WORKERTHREAD #" + workerID);
 			}


### PR DESCRIPTION
Implemented:

+ Program automatically closes after certain period of time on both the server and all the clients.
+ Batch's will automatically disperse keys (aka jobs) to workerThreads when either the batchQueue becomes full or the batchTimer has expired, whatever comes first.
+ Selector is capable of providing register jobs and read&respond jobs to the batchQueue (the variable name for this is pendingJobs in ThreadPoolManager.java) for workerThreads to consume.
+ WorkerThreads can handle message passing indefinitely.
+ WorkerThreads can handle registering ONE CLIENT, changes need to be made so that the selector only switches to OP_READ mode once every single client has already registered with the selector, not sure how to do this yet.
+ All the required data now prints every 20 seconds for both the client and server including more difficult ones that require calculations on the server (per-client average throughput and standard deviation).
