### PR TITLE
Changed server to run for 9999 minutes

### DIFF
--- a/src/cs455/scaling/Server.java
+++ b/src/cs455/scaling/Server.java
@@ -16,7 +16,7 @@ public class Server {
 	public static void main(String[] args) throws IOException {
 	
 		if (args.length == 4){
-			AutomaticExit ae = new AutomaticExit(3);
+			AutomaticExit ae = new AutomaticExit(9999);
 			ae.start();
 			// First argument is portnum
 			int portnum = Integer.parseInt(args[0]);


### PR DESCRIPTION
Before, I accidentally set the client to run for 9999 minutes but not the server, now both the server and the client will run for 9999 minutes before exiting.