### PR TITLE
Major fixes, handling expected inputs provided by the TA, and speeds should be more reasonable now.

### DIFF
--- a/src/cs455/scaling/ClientReceiverThread.java
+++ b/src/cs455/scaling/ClientReceiverThread.java
@@ -39,8 +39,14 @@ public class ClientReceiverThread extends Thread{
             	clientChannel.read(readBuffer);
 				byte[] response = readBuffer.array();
 				String responseString = new String(response);
-				int messageLength = Integer.parseInt(responseString.substring(0,2));
-				String messageString = responseString.substring(2,2+messageLength); // Trim excess padded zeros off of string
+				int iteratorCount = 0;
+				int numMessagesInBuffer = (int) ((double) responseString.length() / 39.00);
+				// System.out.println("num messages in buffer is about: " + numMessagesInBuffer);
+				int messageLength = Integer.parseInt(responseString.substring(iteratorCount,2));
+				for (int i = 0; i < numMessagesInBuffer; i+=messageLength){
+
+				messageLength = Integer.parseInt(responseString.substring(iteratorCount,2));
+				String messageString = responseString.substring(iteratorCount+2,2+messageLength); // Trim excess padded zeros off of string
 				boolean verified = false;
                 LinkedList<String> unverifiedHashes = client.getUnverifiedHashes();
 
@@ -51,7 +57,7 @@ public class ClientReceiverThread extends Thread{
 					unverifiedHashes.remove(messageString);
 					client.incrementTotalReceived();
 				}
-				// else {
+				else {
 					// System.out.println("\tReceived an unverified string!");
 					// System.out.println("\tUnverified string: " + messageString + " length: " + messageString.length());
 					// System.out.println("\tSize of list of hashes: " + client.getUnverifiedHashes().size());
@@ -62,8 +68,8 @@ public class ClientReceiverThread extends Thread{
 						// }
 					// }
 
-				// }
-
+				}
+			}
 				readBuffer.clear();
             }
             catch (IOException e){

--- a/src/cs455/scaling/ClientReceiverThread.java
+++ b/src/cs455/scaling/ClientReceiverThread.java
@@ -51,18 +51,18 @@ public class ClientReceiverThread extends Thread{
 					unverifiedHashes.remove(messageString);
 					client.incrementTotalReceived();
 				}
-				else {
+				// else {
 					// System.out.println("\tReceived an unverified string!");
 					// System.out.println("\tUnverified string: " + messageString + " length: " + messageString.length());
 					// System.out.println("\tSize of list of hashes: " + client.getUnverifiedHashes().size());
-					for (String hashString: client.getUnverifiedHashes()){
-						String partOfNH = hashString.substring(0,10);
-						if (partOfRS == partOfNH){
+					// for (String hashString: client.getUnverifiedHashes()){
+						// String partOfNH = hashString.substring(0,10);
+						// if (partOfRS == partOfNH){
 							// System.out.println("Found a match, size in response: " + responseString.length() + ", size in hash list: "+ hashString.length());
-						}
-					}
+						// }
+					// }
 
-				}
+				// }
 
 				readBuffer.clear();
             }

--- a/src/cs455/scaling/KeySelector.java
+++ b/src/cs455/scaling/KeySelector.java
@@ -69,14 +69,14 @@ public class KeySelector extends Thread{
 						key.attach(this);
 						// Add register task to pendingTasks in threadPoolManager so that the threadPools can handle those
 						if (!tpm.addTask(key)){
-							break;
+							continue;
 						}
 					}
 
 					if (key.isReadable()) {
 						// Add read-write task to pendingTasks in threadPoolManager so that the threadPools can handle those
 						if (!tpm.addTask(key)){
-							break;
+							continue;
 						}
 					}
 

--- a/src/cs455/scaling/KeySelector.java
+++ b/src/cs455/scaling/KeySelector.java
@@ -68,12 +68,16 @@ public class KeySelector extends Thread{
 					if (key.isAcceptable()) {
 						key.attach(this);
 						// Add register task to pendingTasks in threadPoolManager so that the threadPools can handle those
-						tpm.addTask(key);
+						if (!tpm.addTask(key)){
+							break;
+						}
 					}
 
 					if (key.isReadable()) {
 						// Add read-write task to pendingTasks in threadPoolManager so that the threadPools can handle those
-						tpm.addTask(key);
+						if (!tpm.addTask(key)){
+							break;
+						}
 					}
 
 					// Remove from the set when done

--- a/src/cs455/scaling/PrintStatsThread.java
+++ b/src/cs455/scaling/PrintStatsThread.java
@@ -53,11 +53,11 @@ public class PrintStatsThread extends Thread{
         if (nodeType == type.CLIENT) {
             try {
                 while (true) {
+                    Thread.sleep(20000);
                     LocalDateTime currentTime = LocalDateTime.now();
                     System.out.println("[" + currentTime + "] Total Sent Count: " + client.getTotalSent() + ", Total Received Count: " + client.getTotalReceived());
                     client.resetTotalReceived();
                     client.resetTotalSent();
-                    Thread.sleep(20000);
                 }
             } catch (Exception e) {
                 e.printStackTrace();
@@ -67,12 +67,13 @@ public class PrintStatsThread extends Thread{
         if (nodeType == type.TPM) {
             try {
                 while (true) {
+                    this.startTime = Instant.now();
+                    Thread.sleep(20000);
                     LocalDateTime currentTime = LocalDateTime.now();
                     Instant endTime = Instant.now();
                     long preciseDuration = (Duration.between(startTime, endTime).toMillis()) / 1000; // converting per millisecond unit rate to per second rate (1000ms = 1s) 
                     preciseDuration = preciseDuration == 0 ? 1 : preciseDuration; // Prevent divide by zero error if the program just started and the timer hasn't started yet
                     double averageSent = (double)(tpm.getTotalSent()) / (double) preciseDuration;
-                    // double averageSent = (double)tpm.getTotalSent();
                     long numNodesConnected = (long) tpm.getNumNodesConnected() == 0 ? 1 : (long) tpm.getNumNodesConnected(); // Prevent divide by zero error if the program just started and no nodes have connected yet
                     double meanPerClientTP = averageSent / (double) numNodesConnected;
                     throughPutAverages.add(meanPerClientTP);
@@ -83,8 +84,6 @@ public class PrintStatsThread extends Thread{
                     df.format(meanPerClientTP);
                     System.out.println("[" + currentTime + "] Server Throughput: " + averageSent + " messages/s, Active Client Connections: " + tpm.getNumNodesConnected() + ", Mean Per-client Throughput: " + meanPerClientTP + " messages/s, Std. Dev. Of Per-client Throughput: " + stdDev + " messages/s");
                     this.tpm.resetTotalSent();
-                    this.startTime = Instant.now();
-                    Thread.sleep(20000);
                 }
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/cs455/scaling/Server.java
+++ b/src/cs455/scaling/Server.java
@@ -16,7 +16,7 @@ public class Server {
 	public static void main(String[] args) throws IOException {
 	
 		if (args.length == 4){
-			AutomaticExit ae = new AutomaticExit(3);
+			AutomaticExit ae = new AutomaticExit(9999);
 			ae.start();
 			// First argument is portnum
 			int portnum = Integer.parseInt(args[0]);

--- a/src/cs455/scaling/ThreadPoolManager.java
+++ b/src/cs455/scaling/ThreadPoolManager.java
@@ -148,26 +148,11 @@ public class ThreadPoolManager extends Thread{
 		}
 	}
 
-	private boolean pendingTasksContainsRegistry(){
-		return false;
-		// synchronized (this){
-		// 	if (pendingTasks.size() != 0){
-		// 		for (SelectionKey sk: pendingTasks){
-		// 			if (sk.isAcceptable()){
-		// 				return true;
-		// 			}
-		// 		}
-		// 	}
-		// 	return false;
-		// }
-	}
-
 	public void checkForNewKeys(){
 		while (true){
 			int batchLoad = getPendingTasks().size();
 			boolean batchReady = batchTimer.getBatchReadyStatus();
-			boolean batchContainsRegistry = pendingTasksContainsRegistry();
-			if (batchLoad == batchSize || batchReady == true || pendingTasksContainsRegistry()){
+			if (batchLoad == batchSize || batchReady == true ){
 				while (getPendingTasks().size() != 0){ // Start assigning keys to threads until it's empty
 					synchronized(this){
 						LinkedList<SelectionKey> currentKeys = this.getPendingTasks();

--- a/src/cs455/scaling/ThreadPoolManager.java
+++ b/src/cs455/scaling/ThreadPoolManager.java
@@ -9,18 +9,19 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ThreadPoolManager extends Thread{
 
-	private int totalMessagesSent = 0;
-	private int totalMessagesReceived = 0;
+	private AtomicInteger totalMessagesSent = new AtomicInteger(0);
+	private AtomicInteger totalMessagesReceived = new AtomicInteger(0);
 
 
 	// Number of threads to initialize and keep alive for the duration of the program
 	private final int numThreads;
 
 	// Number of threads to initialize and keep alive for the duration of the program
-	private int totalNumConnections;
+	private AtomicInteger totalNumConnections = new AtomicInteger(0);
 
 	// Port Number the Server is listening on
 	private final int portnum;
@@ -39,7 +40,6 @@ public class ThreadPoolManager extends Thread{
 
 	// Class for managing time between last batch was dispersed to workerThreads
 	private BatchTimer batchTimer;
-
 
 	//Used for debugging purposes to keep track of the number of tasks generated variables (DELETE WHEN NO LONGER NEEDED)
 	int totalNumTasks = 0;
@@ -73,10 +73,14 @@ public class ThreadPoolManager extends Thread{
 		}
 	} 
 
-	public void addTask(SelectionKey key){
+	public boolean addTask(SelectionKey key){
 			if (!getPendingTasks().contains(key) && getPendingTasks().size() < batchSize){
 					addKey(key);
+					return true;
 				}
+			else {
+				return false;
+			}
 	}
 
 	public boolean addKey(SelectionKey key){
@@ -85,36 +89,36 @@ public class ThreadPoolManager extends Thread{
 		}
 	}
 
-	public synchronized int getTotalSent(){
-		return totalMessagesSent;
+	public int getTotalSent(){
+		return totalMessagesSent.get();
 	}
 
-	public synchronized void resetTotalSent(){
-		this.totalMessagesSent= 0;
+	public void resetTotalSent(){
+		totalMessagesSent.set(0);
 	}
 	
-	public synchronized int getTotalMessagesReceived(){
-		return totalMessagesReceived;
+	public int getTotalMessagesReceived(){
+		return totalMessagesReceived.get();
 	}
 
-	public synchronized void decrementNodesConnected(){
-		--totalNumConnections;
+	public void decrementNodesConnected(){
+		totalNumConnections.decrementAndGet();
 	}	
 
-	public synchronized void incrementNodesConnected(){
-		++totalNumConnections;
+	public void incrementNodesConnected(){
+		totalNumConnections.incrementAndGet();
 	}
 
-	public synchronized int getNumNodesConnected(){
-		return totalNumConnections;
+	public int getNumNodesConnected(){
+		return totalNumConnections.get();
 	}
 
-	public synchronized void incrementTotalReceived(){
-		++totalMessagesReceived;
+	public void incrementTotalReceived(){
+		totalMessagesReceived.incrementAndGet();
 	}
 	
-	public synchronized void incrementTotalSent(){
-		++totalMessagesSent;
+	public void incrementTotalSent(){
+		totalMessagesSent.incrementAndGet();
 	}
 
 	public LinkedList<SelectionKey> getPendingTasks(){
@@ -130,16 +134,17 @@ public class ThreadPoolManager extends Thread{
 	}
 
 	private boolean pendingTasksContainsRegistry(){
-		synchronized (this){
-			if (pendingTasks.size() != 0){
-				for (SelectionKey sk: pendingTasks){
-					if (sk.isAcceptable()){
-						return true;
-					}
-				}
-			}
-			return false;
-		}
+		return false;
+		// synchronized (this){
+		// 	if (pendingTasks.size() != 0){
+		// 		for (SelectionKey sk: pendingTasks){
+		// 			if (sk.isAcceptable()){
+		// 				return true;
+		// 			}
+		// 		}
+		// 	}
+		// 	return false;
+		// }
 	}
 
 	public void checkForNewKeys(){

--- a/src/cs455/scaling/WorkerThread.java
+++ b/src/cs455/scaling/WorkerThread.java
@@ -18,7 +18,6 @@ public class WorkerThread extends Thread{
     private static ThreadPoolManager tpm;
     private SelectionKey nextKey = null;
     public int workerID = -1;
-    protected Vector<String> allMessages = new Vector<String>();
 
     public WorkerThread(int workerID, ThreadPoolManager tpm){
         this.workerID = workerID;


### PR DESCRIPTION
After receiving feedback on reasonable values to test on, running $ server {portnum} 10 10 10  with more than 50 clients trying to connect would cause the server to incrementally add nodes up until 10 nodes and then it would hang for unknown reasons. We found that decreasing the batchTime to below a value of 10 would prevent this issue from happening but after receiving info from the TA that the batchTime should be between 10 and 20 seconds this issue needed to be addressed.

I figured out this was due to a synchronization issue with keys sometimes being added in back-to-back queues and therefor the same key being read and responded to twice, fixing this also fixed alot of other issues including clients receiving back the same message twice which caused the unverified message to pop up on the client terminals, I believe this is fixed now.
 

Before it was setup so that the batch would immediately dump to the workerThreads if a registryKey was present in the batch, this would allow the clients to get a response back faster than having to wait for extended periods of time (maybe even beyond 20 minutes if the batchTime is 20 and the batchSize is 10 with 100 nodes and 1 workerThread), registering clients is done at whatever speed the batch is capable of doing and the client will continue to try to connect to the server in an infinite loop until it is successful which fixes the issue of clients timing out.